### PR TITLE
Figmaデザインに基づくButtonページの実装

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,32 @@ import { Button } from "@/components/ui/button.tsx";
 function App() {
   return (
     <>
-      <div className="flex flex-col items-center justify-center min-h-svh">
-        <Button>Click me</Button>
+      <div className="flex flex-col items-center min-h-svh p-8 gap-16">
+        <div className="flex flex-col items-center gap-8">
+          <div className="flex flex-row gap-12">
+            <div className="flex flex-col gap-4">
+              <h1 className="text-3xl font-semibold text-[#0F172A]">Button</h1>
+              <p className="text-xl text-[#475569]">
+                Displays a button or a component that looks like a button.
+              </p>
+            </div>
+            <div className="flex items-center">
+              <Button 
+                className="bg-[#0F172A] text-white"
+                onClick={() => window.open("https://ui.shadcn.com", "_blank")}
+              >
+                View docs
+              </Button>
+            </div>
+          </div>
+          <div className="w-full h-px bg-[#E2E8F0]" />
+        </div>
+        <Button
+          className="bg-[#0F172A] text-white"
+          onClick={() => window.open("https://ui.shadcn.com/docs/components/button", "_blank")}
+        >
+          Continue
+        </Button>
       </div>
     </>
   );


### PR DESCRIPTION
## 概要
Figmaデザインに基づいて、Buttonページのレイアウトを実装しました。shadcnのUIコンポーネントを使用し、デザインに忠実な画面を構築しています。

## 変更点
- Buttonタイトル（h1）の追加
- コンポーネントの説明文の追加
- View docsボタンの追加（shadcnのトップページへリンク）
- 区切り線の追加
- Continueボタンの追加（shadcnのボタンコンポーネントページへリンク）
- Figmaデザインに忠実なレイアウト・配色の実装

## 必要な動作確認
- 正しいレイアウトでページが表示されること
- 「View docs」ボタンをクリックすると、shadcnのトップページ（https://ui.shadcn.com）が開くこと
- 「Continue」ボタンをクリックすると、shadcnのボタンコンポーネントページ（https://ui.shadcn.com/docs/components/button）が開くこと

## スクリーンショット
（実装後の画面キャプチャがあると、レビューがしやすくなります）