### PR TITLE
Figmaデザインに基づいたボタンUIの実装

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,37 @@ import { Button } from "@/components/ui/button.tsx";
 
 function App() {
   return (
-    <>
-      <div className="flex flex-col items-center justify-center min-h-svh">
-        <Button>Click me</Button>
+    <div className="flex flex-col items-center gap-16 px-8 pt-8 pb-16 min-h-svh bg-white">
+      <div className="flex flex-col items-center gap-8">
+        <div className="flex flex-row gap-[45px] items-start">
+          <div className="flex flex-col gap-4">
+            <h1 className="text-3xl font-semibold text-[#0F172A] leading-tight tracking-tight">
+              Button
+            </h1>
+            <p className="text-xl text-[#475569] leading-relaxed max-w-md">
+              Displays a button or a component that looks like a button.
+            </p>
+          </div>
+          <div className="flex items-center">
+            <Button
+              className="text-sm font-medium text-white bg-[#0F172A] hover:bg-[#0F172A]/90 w-24"
+              onClick={() => window.open("https://ui.shadcn.com/", "_blank")}
+            >
+              View docs
+            </Button>
+          </div>
+        </div>
+        <hr className="border-t border-[#E2E8F0] w-full" />
       </div>
-    </>
+      <Button
+        className="text-sm font-medium"
+        onClick={() =>
+          window.open("https://ui.shadcn.com/docs/components/button", "_blank")
+        }
+      >
+        Continue
+      </Button>
+    </div>
   );
 }
 


### PR DESCRIPTION
## 変更内容

Notionの「デモ用仕様ページ」およびFigmaデザインに基づいて、ボタンUIを実装しました。

### 主な変更点
- タイトル「Button」をh1タグで表示
- 説明文の追加
- 水平線の追加
- 「View docs」ボタンの実装（クリックするとshadcnのトップページに遷移）
- 「Continue」ボタンの実装（クリックするとshadcnのボタンコンポーネントページに遷移）
- Figmaデザインに忠実なレイアウト構成（横並び配置、適切な間隔設定）

## 動作確認の観点
1. UIレイアウトの確認
   - Figmaデザインと一致しているか
   - レスポンシブ対応が適切か

2. ボタン機能の確認
   - 「View docs」ボタンをクリックすると、shadcnのトップページ（https://ui.shadcn.com/）に遷移するか
   - 「Continue」ボタンをクリックすると、shadcnのボタンコンポーネントページ（https://ui.shadcn.com/docs/components/button）に遷移するか

3. スタイリングの確認
   - カラー設定が適切か
   - フォントサイズ、ウェイト、行間が適切か
   - ボタンの見た目がFigmaデザインと一致しているか